### PR TITLE
Restrict OAuth scopes to what's actually needed

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Rails.application.config.middleware.use OmniAuth::Builder do
-  provider :mastodon, scope: 'read write', credentials: lambda { |domain, callback_url|
+  provider :mastodon, scope: 'read:accounts write:statuses', credentials: lambda { |domain, callback_url|
     Rails.logger.info "Requested credentials for #{domain} with callback URL #{callback_url}"
 
     instance = Instance.find_or_create_by(host: domain) do |ins|


### PR DESCRIPTION
If my understanding is correct, the app logs in, reads the account's `created_at` field, and offers the user to write a toot.
Therefore, the read permission can be restricted to `read:accounts`, and the write permission to `write:statuses`.